### PR TITLE
added RESET_TABLES to /database_manager/execute service

### DIFF
--- a/toaster_msgs/srv/ExecuteDB.srv
+++ b/toaster_msgs/srv/ExecuteDB.srv
@@ -3,6 +3,7 @@ string type
 toaster_msgs/Fact[] facts
 string agent
 string order
+string newIDList
 bool areaTopic
 bool agentTopic
 bool move3dTopic


### PR DESCRIPTION
To reset all the tables in database and create new fact_table and memory_table according to given id_list (new xml file), use database_manager/execute service with command RESET_TABLES and newIDList as filename of new xml file for id list (it should be saved in database_manager/database e.g. "/database/id_list2.xml")
